### PR TITLE
Added support for fully qualified names of classes. 

### DIFF
--- a/src/main/java/org/jarexplorer/JarExplorer.java
+++ b/src/main/java/org/jarexplorer/JarExplorer.java
@@ -326,6 +326,16 @@ public class JarExplorer extends JFrame {
             progressBar.setIndeterminate(true);
             ArrayList results = index.search(searchTF.getText());
             found = results.size();
+
+            if(found == 0) {
+                results = index.search(Util.convertFqnToPath(searchTF.getText(), false));
+                found = results.size();
+            }
+
+            if(found == 0) {
+                results = index.search(Util.convertFqnToPath(searchTF.getText(), true));
+                found = results.size();
+            }
             resultsPanel.setResults("Found substring '" + searchTF.getText() + "' in all jars:", results);
             progressBar.setValue(0);
             progressBar.setIndeterminate(false);

--- a/src/main/java/org/jarexplorer/Util.java
+++ b/src/main/java/org/jarexplorer/Util.java
@@ -58,4 +58,40 @@ public class Util
         return bout.toByteArray();
     }
 
+    /**
+     * Check if the string is blank.
+     * @param str
+     * @return true if string is empty
+     */
+    public static boolean isBlankString(String str)
+    {
+        return (str == null || "".equals(str.trim()));
+    }
+
+    /**
+     * Converts a fully qualified name of a java class to its path. <br/>
+     * For example: com.hello.world.MainClass.java will converted to com/hello/world/MainClass.java
+     * @param resourceName Fqn of a file with dots
+     * @param withExtension if it includes extension or not.
+     * @return resource path
+     */
+    public static String convertFqnToPath(String resourceName, boolean withExtension)
+    {
+
+        if(isBlankString(resourceName))
+        {
+            return "";
+        }
+
+        if(withExtension)
+        {
+            int lastIndex = resourceName.lastIndexOf('.');
+
+            return resourceName.substring(0, lastIndex).replace(".", "/")
+                    + resourceName.substring(lastIndex);
+        }
+
+        return resourceName.replace(".", "/");
+    }
+
 }


### PR DESCRIPTION
This can help a lot in a scenario when we face exception in the code. We can just copy the full name of class along with package name and search with this tool. Fqn search also helps when we have classes with the same name in different packages.

This change is similar to [this pull request](https://github.com/javalite/jar-explorer/pull/1).